### PR TITLE
Add script for switching to next chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ yarn start
 - [Android link](./docs/simulators-setup.md#yarn-android)
 - [iOS link](./docs/simulators-setup.md#launching-a-specific-simulator)
 
+5. If you'd like to fast forward your assignment to a specific chapter, run this script (replacing the 8 with the chapter you'd like to skip to). This will copy the contents of the given chapter to your app folder.
+
+```bash
+./scripts/skipTo 8
+```
+
 ## Troubleshooting
 
 If you can't get this to work, see the [Troubleshooting](https://reactnative.dev/docs/troubleshooting) page.

--- a/scripts/skipTo
+++ b/scripts/skipTo
@@ -1,0 +1,42 @@
+
+#!/bin/bash
+
+# Exit on error
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Usage: ./switch <chapter_number>"
+    exit 1
+fi
+
+CHAPTER_NUM=$1
+APP_DIR="app"
+CHAPTER_DIR="solutions/chapter${CHAPTER_NUM}"
+
+# Check if chapter directory exists
+if [ ! -d "$CHAPTER_DIR" ]; then
+    echo "Error: Chapter ${CHAPTER_NUM} directory not found"
+    exit 1
+fi
+
+# Prompt for confirmation
+read -p "Are you sure? This will overwrite everything in your app folder (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Operation cancelled"
+    exit 1
+fi
+
+# Remove existing app directory contents
+rm -rf "${APP_DIR:?}"/*
+
+# Copy chapter contents to app directory
+cp -r "$CHAPTER_DIR"/* "$APP_DIR/"
+
+# Find and replace import paths
+find "$APP_DIR" -type f -name "*.ts" -o -name "*.tsx" | while read -r file; do
+    # Replace '../../../shared' with '../../shared'
+    sed -i '' 's/\.\.\/\.\.\/\.\.\/shared/\.\.\/\.\.\/shared/g' "$file"
+done
+
+echo "Successfully skipped to chapter ${CHAPTER_NUM}"


### PR DESCRIPTION
### Summary

Adds a script which copies a specified chapter over into the app folder. It also updates all of the broken imports from the `shared` directory. 

### How to verify

1. `yarn`
2. `yarn start`
3. `i` & `a`

**Expected results**:

### Screenshots
![CleanShot 2025-02-05 at 07 37 06@2x](https://github.com/user-attachments/assets/3470ee72-423d-4d15-98d3-6ac1e37fc323)


